### PR TITLE
Correct Posts order argument

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -71,7 +71,7 @@ class BlogController extends Controller {
 	public function index()
 	{
 		return redirect(route('blog.order', [
-			'name' => 'created_at',
+			'name' => 'posts.created_at',
 			'sens' => 'asc'
 		]));
 	}


### PR DESCRIPTION
When you are using sqlite, the right order need be order?name=posts.created_at&sens=asc, if you just send order?name=created_at&sens=asc it will return an error General error: 1 ambiguous column name: created_at (because user table also has a created_at column.