### PR TITLE
removed pre-update-cmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,10 +44,8 @@
             "php artisan clear-compiled",
             "php artisan optimize"
         ],
-        "pre-update-cmd": [
-            "php artisan clear-compiled"
-        ],
         "post-update-cmd": [
+            "php artisan clear-compiled"
             "php artisan optimize"
         ]
     },


### PR DESCRIPTION
pre-update-cmd is removed in the newest version of composer(updated in March 17th).