### PR TITLE
Vscode folder removed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "git.ignoreLimitWarning": true
-}


### PR DESCRIPTION
Vscode folder is removed since the project doesn't need it, and not everyone is using vscode.